### PR TITLE
Fix loader exception on startup when manual server entries are present

### DIFF
--- a/Source/Loader/Forms/MainForm.cs
+++ b/Source/Loader/Forms/MainForm.cs
@@ -41,6 +41,7 @@ namespace Loader
         {
             InitializeComponent();
 
+            ImportedServerListView.Items.Clear();
             ImportedServerListView.ListViewItemSorter = new ServerListSorter();
 
             MachinePrivateIp = NetUtils.GetMachineIPv4(false);


### PR DESCRIPTION
There's several ways to fix but clearing the list to remove the designer entry is probably the easiest.