### PR TITLE
add dockerfile for master server

### DIFF
--- a/Source/MasterServer/Dockerfile
+++ b/Source/MasterServer/Dockerfile
@@ -1,0 +1,6 @@
+FROM docker.io/node:17.6.0-alpine3.14
+COPY . /app
+WORKDIR /app
+RUN npm install;
+EXPOSE 50020/tcp
+ENTRYPOINT ["npm", "run", "start:dev"]


### PR DESCRIPTION
tested working locally :)

build with similar to:
```sh
docker build -t ds3os-masterserver:v0.18.0.0-main ./Source/MasterServer
```

run with similar to;
```sh
docker run -ti --rm --net=host ds3os-masterserver:v0.18.0.0-main # --net=host is a bad idea in general and should be used only for testing
```
