### PR TITLE
Fix OOB read bug and change code style in NRSSR sanitizer

### DIFF
--- a/Source/Server/Server/GameService/GameManagers/BloodMessage/BloodMessageManager.cpp
+++ b/Source/Server/Server/GameService/GameManagers/BloodMessage/BloodMessageManager.cpp
@@ -252,9 +252,9 @@ MessageHandleResult BloodMessageManager::Handle_RequestCreateBloodMessage(GameCl
     MessageData.assign(Request->message_data().data(), Request->message_data().data() + Request->message_data().size());
 
     // There is no NRSSR struct in blood messsage data, but we still make sure the size-delimited entry list is valid.
-    if (BuildConfig::NRSSR_SANITY_CHECKS)
+    if constexpr (BuildConfig::NRSSR_SANITY_CHECKS)
     {
-        auto ValidationResult = NRSSRSanitizer::IsValidEntryList(MessageData.data(), MessageData.size());
+        auto ValidationResult = NRSSRSanitizer::ValidateEntryList(MessageData.data(), MessageData.size());
         if (ValidationResult != NRSSRSanitizer::ValidationResult::Valid)
         {
             WarningS(Client->GetName().c_str(), "Blood message data recieved from client is invalid (error code %i).",

--- a/Source/Server/Server/GameService/GameManagers/Bloodstain/BloodstainManager.cpp
+++ b/Source/Server/Server/GameService/GameManagers/Bloodstain/BloodstainManager.cpp
@@ -95,9 +95,9 @@ MessageHandleResult BloodstainManager::Handle_RequestCreateBloodstain(GameClient
     GhostData.assign(Request->ghost_data().data(), Request->ghost_data().data() + Request->ghost_data().size());
 
     // There is no NRSSR struct in bloodstain or ghost data, but we still make sure the size-delimited entry list is valid.
-    if (BuildConfig::NRSSR_SANITY_CHECKS)
+    if constexpr (BuildConfig::NRSSR_SANITY_CHECKS)
     {
-        auto ValidationResult = NRSSRSanitizer::IsValidEntryList(Data.data(), Data.size());
+        auto ValidationResult = NRSSRSanitizer::ValidateEntryList(Data.data(), Data.size());
         if (ValidationResult != NRSSRSanitizer::ValidationResult::Valid)
         {
             WarningS(Client->GetName().c_str(), "Bloodstain metadata recieved from client is invalid (error code %i).",
@@ -105,7 +105,7 @@ MessageHandleResult BloodstainManager::Handle_RequestCreateBloodstain(GameClient
 
             return MessageHandleResult::Handled;
         }
-        ValidationResult = NRSSRSanitizer::IsValidEntryList(GhostData.data(), GhostData.size());
+        ValidationResult = NRSSRSanitizer::ValidateEntryList(GhostData.data(), GhostData.size());
         if (ValidationResult != NRSSRSanitizer::ValidationResult::Valid)
         {
             WarningS(Client->GetName().c_str(), "Ghost data recieved from client is invalid (error code %i).",

--- a/Source/Server/Server/GameService/GameManagers/Ghosts/GhostManager.cpp
+++ b/Source/Server/Server/GameService/GameManagers/Ghosts/GhostManager.cpp
@@ -89,9 +89,9 @@ MessageHandleResult GhostManager::Handle_RequestCreateGhostData(GameClient* Clie
     Data.assign(Request->data().data(), Request->data().data() + Request->data().size());
 
     // There is no NRSSR struct in ghost data, but we still make sure the size-delimited entry list is valid.
-    if (BuildConfig::NRSSR_SANITY_CHECKS)
+    if constexpr (BuildConfig::NRSSR_SANITY_CHECKS)
     {
-        auto ValidationResult = NRSSRSanitizer::IsValidEntryList(Data.data(), Data.size());
+        auto ValidationResult = NRSSRSanitizer::ValidateEntryList(Data.data(), Data.size());
         if (ValidationResult != NRSSRSanitizer::ValidationResult::Valid)
         {
             WarningS(Client->GetName().c_str(), "Ghost data recieved from client is invalid (error code %i).",

--- a/Source/Server/Server/GameService/GameManagers/Misc/MiscManager.cpp
+++ b/Source/Server/Server/GameService/GameManagers/Misc/MiscManager.cpp
@@ -128,7 +128,7 @@ MessageHandleResult MiscManager::Handle_RequestSendMessageToPlayers(GameClient* 
     // The game seems to only use this function in the BreakIn (invasions) implementation.
     // Hence we should make sure that a malicious client does not use this send arbitrary data to other players.
     bool ShouldProcessRequest = true;
-    if (BuildConfig::SEND_MESSAGE_TO_PLAYERS_SANITY_CHECKS)
+    if constexpr (BuildConfig::SEND_MESSAGE_TO_PLAYERS_SANITY_CHECKS)
     {
         // The request should contain a PushRequestBreakInTarget message
         Frpg2RequestMessage::PushRequestAllowBreakInTarget EmbdeddedMsg;
@@ -146,9 +146,9 @@ MessageHandleResult MiscManager::Handle_RequestSendMessageToPlayers(GameClient* 
             ShouldProcessRequest = false;
         }
         // Make sure the NRSSR data contained within this message is valid (if the CVE-2022-24126 fix is enabled)
-        else if (BuildConfig::NRSSR_SANITY_CHECKS)
+        else if constexpr (BuildConfig::NRSSR_SANITY_CHECKS)
         {
-            auto ValidationResult = NRSSRSanitizer::IsValidEntryList(EmbdeddedMsg.player_struct().data(), EmbdeddedMsg.player_struct().size());
+            auto ValidationResult = NRSSRSanitizer::ValidateEntryList(EmbdeddedMsg.player_struct().data(), EmbdeddedMsg.player_struct().size());
             if (ValidationResult != NRSSRSanitizer::ValidationResult::Valid)
             {
                 WarningS(Client->GetName().c_str(), "PushRequestAllowBreakInTarget message recieved from client contains ill formated binary data (error code %i).",

--- a/Source/Server/Server/GameService/GameManagers/QuickMatch/QuickMatchManager.cpp
+++ b/Source/Server/Server/GameService/GameManagers/QuickMatch/QuickMatchManager.cpp
@@ -362,9 +362,9 @@ MessageHandleResult QuickMatchManager::Handle_RequestAcceptQuickMatch(GameClient
 
     bool ShouldProcessRequest = true;
     // Make sure the NRSSR data contained within this message is valid (if the CVE-2022-24126 fix is enabled)
-    if (BuildConfig::NRSSR_SANITY_CHECKS)
+    if constexpr (BuildConfig::NRSSR_SANITY_CHECKS)
     {
-        auto ValidationResult = NRSSRSanitizer::IsValidEntryList(Request->data().data(), Request->data().size());
+        auto ValidationResult = NRSSRSanitizer::ValidateEntryList(Request->data().data(), Request->data().size());
         if (ValidationResult != NRSSRSanitizer::ValidationResult::Valid)
         {
             WarningS(Client->GetName().c_str(), "RequestAcceptQuickMatch message recieved from client contains ill formated binary data (error code %i).",

--- a/Source/Server/Server/GameService/GameManagers/Signs/SignManager.cpp
+++ b/Source/Server/Server/GameService/GameManagers/Signs/SignManager.cpp
@@ -234,9 +234,9 @@ MessageHandleResult SignManager::Handle_RequestCreateSign(GameClient* Client, co
     Frpg2RequestMessage::RequestCreateSign* Request = (Frpg2RequestMessage::RequestCreateSign*)Message.Protobuf.get();
 
     // There is no NRSSR struct in the sign metadata, but we still make sure the size-delimited entry list is valid.
-    if (BuildConfig::NRSSR_SANITY_CHECKS)
+    if constexpr (BuildConfig::NRSSR_SANITY_CHECKS)
     {
-        auto ValidationResult = NRSSRSanitizer::IsValidEntryList(Request->player_struct().data(), Request->player_struct().size());
+        auto ValidationResult = NRSSRSanitizer::ValidateEntryList(Request->player_struct().data(), Request->player_struct().size());
         if (ValidationResult != NRSSRSanitizer::ValidationResult::Valid)
         {
             WarningS(Client->GetName().c_str(), "RequestCreateSign message recieved from client contains ill formated binary data (error code %i).",
@@ -342,7 +342,7 @@ MessageHandleResult SignManager::Handle_RequestSummonSign(GameClient* Client, co
     // Make sure the NRSSR data contained within this message is valid (if the CVE-2022-24126 fix is enabled)
     if (BuildConfig::NRSSR_SANITY_CHECKS)
     {
-        auto ValidationResult = NRSSRSanitizer::IsValidEntryList(Request->player_struct().data(), Request->player_struct().size());
+        auto ValidationResult = NRSSRSanitizer::ValidateEntryList(Request->player_struct().data(), Request->player_struct().size());
         if (ValidationResult != NRSSRSanitizer::ValidationResult::Valid)
         {
             WarningS(Client->GetName().c_str(), "RequestSummonSign message recieved from client contains ill formated binary data (error code %i).",

--- a/Source/Server/Server/GameService/GameManagers/Signs/SignManager.cpp
+++ b/Source/Server/Server/GameService/GameManagers/Signs/SignManager.cpp
@@ -340,7 +340,7 @@ MessageHandleResult SignManager::Handle_RequestSummonSign(GameClient* Client, co
     bool bSuccess = true;
 
     // Make sure the NRSSR data contained within this message is valid (if the CVE-2022-24126 fix is enabled)
-    if (BuildConfig::NRSSR_SANITY_CHECKS)
+    if constexpr (BuildConfig::NRSSR_SANITY_CHECKS)
     {
         auto ValidationResult = NRSSRSanitizer::ValidateEntryList(Request->player_struct().data(), Request->player_struct().size());
         if (ValidationResult != NRSSRSanitizer::ValidationResult::Valid)

--- a/Source/Server/Server/GameService/GameManagers/Visitor/VisitorManager.cpp
+++ b/Source/Server/Server/GameService/GameManagers/Visitor/VisitorManager.cpp
@@ -128,9 +128,9 @@ MessageHandleResult VisitorManager::Handle_RequestVisit(GameClient* Client, cons
     bool bSuccess = true;
 
     // Make sure the NRSSR data contained within this message is valid (if the CVE-2022-24126 fix is enabled)
-    if (BuildConfig::NRSSR_SANITY_CHECKS)
+    if constexpr (BuildConfig::NRSSR_SANITY_CHECKS)
     {
-        auto ValidationResult = NRSSRSanitizer::IsValidEntryList(Request->data().data(), Request->data().size());
+        auto ValidationResult = NRSSRSanitizer::ValidateEntryList(Request->data().data(), Request->data().size());
         if (ValidationResult != NRSSRSanitizer::ValidationResult::Valid)
         {
             WarningS(Client->GetName().c_str(), "RequestVisit message recieved from client contains ill formated binary data (error code %i).",

--- a/Source/Server/Server/GameService/Utils/NRSSRSanitizer.h
+++ b/Source/Server/Server/GameService/Utils/NRSSRSanitizer.h
@@ -152,8 +152,9 @@ public:
 				pos += 8;
 				break;
 			case 4: // Case 4 : Null-terminated wide string field
-				len = wcsnlen_s((wchar_t*)(nrssr_data + pos), size - pos);
-				if (len == size - pos || len >= MAX_PROP_WSTR_SIZE) return ValidationResult::NRSSR_PropertyString_Overflow;
+				size_t max_wstr_len = (size - pos) / 2;
+				len = wcsnlen_s((wchar_t*)(nrssr_data + pos), max_wstr_len);
+				if (len >= max_wstr_len || len >= MAX_PROP_WSTR_SIZE) return ValidationResult::NRSSR_PropertyString_Overflow;
 				pos += 2 * (len + 1);
 				break;
 			default:
@@ -162,8 +163,9 @@ public:
 		}
 
 		// Check host name
-		len = wcsnlen_s((wchar_t*)(nrssr_data + pos), size - pos);
-		if (len == size - pos || len >= MAX_NAME_WSTR_SIZE) return ValidationResult::NRSSR_NameString_Overflow;
+		size_t max_wstr_len = (size - pos) / 2;
+		len = wcsnlen_s((wchar_t*)(nrssr_data + pos), max_wstr_len);
+		if (len >= max_wstr_len || len >= MAX_NAME_WSTR_SIZE) return ValidationResult::NRSSR_NameString_Overflow;
 		pos += 2 * (len + 1);
 
 		// Check host online id and session data size


### PR DESCRIPTION
Fix a bug where the maximum size to wcsnlen_s was passed in bytes instead of `wchar_t`. 

I don't know how this one slipped past when I reviewed my code, it's a pretty silly mistake. If not patched it can lead to an OOB read that could be used to trigger an access violation in very specific circumstances. 

Edit: Saw your comment in my first pull request and edited the code style to match the rest of the project. 