### PR TITLE
Nitpick: Report Config.DisableCoopAutoSummon state correctly in the server log.

### DIFF
--- a/Source/Server/Server/Server.cpp
+++ b/Source/Server/Server/Server.cpp
@@ -199,7 +199,7 @@ bool Server::Init()
     WriteState("Blood Messages", !Config.DisableBloodMessages);
     WriteState("Blood Stains", !Config.DisableBloodStains);
     WriteState("Blood Ghosts", !Config.DisableGhosts);
-    WriteState("Invasions (Auto Summon)", !Config.DisableCoopAutoSummon);
+    WriteState("Invasions (Auto Summon)", !Config.DisableInvasionAutoSummon);
     WriteState("Invasions", !Config.DisableInvasions);
     WriteState("Coop (Auto Summon)", !Config.DisableCoopAutoSummon);
     WriteState("Coop", !Config.DisableCoop);


### PR DESCRIPTION
I noticed that Config.DisableCoopAutoSummon wasn't correctly represented in the server log because Config.DisableCoopAutoSummon was read instead. The value itself is correctly used in code, just reported wrong.