### PR TITLE
character name checking for exotic characters (issue #167)

### DIFF
--- a/Source/Server/Core/Utils/Strings.cpp
+++ b/Source/Server/Core/Utils/Strings.cpp
@@ -12,6 +12,7 @@
 #include <sstream>
 #include <iomanip>
 #include <string>
+#include <codecvt>
 
 std::string BytesToHex(const std::vector<uint8_t>& Bytes)
 {
@@ -91,4 +92,20 @@ std::string TrimString(const std::string& input)
     }
 
     return input.substr(startWhiteCount, input.size() - startWhiteCount - endWhiteCount);
+}
+
+// For working with exotic characters, such as 
+// chinese or japanese letters.
+std::string WidestringToBytes(std::wstring const& widestring)
+{
+    std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> convert;
+    std::string bytes = convert.to_bytes(widestring);
+    return bytes;
+}
+
+std::wstring BytesToWidestring(std::string const& bytes)
+{
+    std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> convert;
+    std::wstring widestring = convert.from_bytes(bytes);
+    return widestring;
 }

--- a/Source/Server/Core/Utils/Strings.h
+++ b/Source/Server/Core/Utils/Strings.h
@@ -31,3 +31,7 @@ std::string StringFormat(const char* format, Args... args)
 }
 
 std::string TrimString(const std::string& input);
+
+std::string WidestringToBytes(const std::wstring& widestring);
+
+std::wstring BytesToWidestring(std::string const& bytes);

--- a/Source/Server/Server/GameService/GameManagers/AntiCheat/Triggers/AntiCheatTrigger_InvalidName.cpp
+++ b/Source/Server/Server/GameService/GameManagers/AntiCheat/Triggers/AntiCheatTrigger_InvalidName.cpp
@@ -25,12 +25,12 @@ bool AntiCheatTrigger_InvalidName::Scan(std::shared_ptr<GameClient> client, std:
     auto& AllStatus = client->GetPlayerState().GetPlayerStatus();
     if (AllStatus.has_player_status())
     {
-        std::string name = TrimString(AllStatus.player_status().name());
+        std::wstring wideName = BytesToWidestring(AllStatus.player_status().name());
 
-        // Check trimmed length of name is valid.
-        if (name.size() < k_min_name_length || name.size() > k_max_name_length)
+        // Check if length of widestring name is valid.
+        if (wideName.size() < k_min_name_length || wideName.size() > k_max_name_length)
         {
-            extraInfo = StringFormat("Name '%s' has invalid length of %zi.", name.c_str(), name.size());
+            extraInfo = StringFormat("Name '%s' has invalid length of %zi.", WidestringToBytes(wideName), wideName.size());
             return true;
         }
     }


### PR DESCRIPTION
This change resolves #167 by converting the character name to a widestring and checking the length of said widestring.
### Example:
Name: いぎさかか 
- Old - Length = 0, Invalid
- New - Length = 5, Valid