### PR TITLE
Add nix as alternative to docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   workflow_dispatch:
   push:
+  pull_request:
 
 env:
   # Path to the solution file relative to the root of the project.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,21 @@ jobs:
     - name: Build
       working-directory: ${{github.workspace}}/intermediate/make
       run: make
+
+  build-nix-gcc:
+    name: Build nix w/ gcc
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - run: nix build -L .
+
+  build-nix-clang:
+    name: Build nix w/ clang
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - run: nix build -L .#clang

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ node_modules/
 Tools/Utilities/ScyllaHide/
 Tools/Utilities/ServerAddressFinder/
 Tools/Deploy/
+
+# for nix build .
+result

--- a/README.md
+++ b/README.md
@@ -113,6 +113,17 @@ We use cmake for generating project files. You can either use the cmake frontend
 
 Once generated the project files are stored in the intermediate folder, at this point you can just open them and build the project.
 
+## Using nix
+
+```sh
+# to build a package
+nix build github:TLeonardUK/ds3os
+# to run it directly
+nix run github:TLeonardUK/ds3os
+```
+
+The nix version stores the configs in `${XDG_CONFIG_HOME:-$HOME/.config}/ds3os`
+
 # Whats in the repository?
 ```
 /

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Once generated the project files are stored in the intermediate folder, at this 
 nix build github:TLeonardUK/ds3os
 # to run it directly
 nix run github:TLeonardUK/ds3os
+# to run master-server
+nix run github:TLonardUK/ds3os#master-server
 ```
 
 The nix version stores the configs in `${XDG_CONFIG_HOME:-$HOME/.config}/ds3os`

--- a/Source/Loader/Utils/SteamUtils.cs
+++ b/Source/Loader/Utils/SteamUtils.cs
@@ -91,6 +91,10 @@ namespace Loader
 
         public static bool IsSteamRunningAndLoggedIn()
         {
+            if (Environment.GetEnvironmentVariable("YES_STEAM_IS_RUNNING") == "1")
+            {
+                return true;
+            }
             object? ActiveUserValue = Registry.GetValue(@"HKEY_CURRENT_USER\SOFTWARE\Valve\Steam\ActiveProcess", "ActiveUser", 0);
             object? ActivePidValue = Registry.GetValue(@"HKEY_CURRENT_USER\SOFTWARE\Valve\Steam\ActiveProcess", "pid", 0);
             if (ActiveUserValue == null || ActiveUserValue is not int)

--- a/Source/Server/Server/Streams/Frpg2Packet.h
+++ b/Source/Server/Server/Streams/Frpg2Packet.h
@@ -13,6 +13,7 @@
 
 #include <vector>
 #include <string>
+#include <cstdint>
 
 // See ds3server_packet.bt for commentry on what each of these
 // fields appears to represent.

--- a/Source/Server/Server/Streams/Frpg2ReliableUdpPacket.h
+++ b/Source/Server/Server/Streams/Frpg2ReliableUdpPacket.h
@@ -13,6 +13,7 @@
 
 #include <vector>
 #include <string>
+#include <cstdint>
 
 // Every packet can perform one of the below operations. This is basically
 // just a crude reimplementation of most of the TCP operations.

--- a/Source/Shared/Core/Network/NetIPAddress.h
+++ b/Source/Shared/Core/Network/NetIPAddress.h
@@ -11,6 +11,7 @@
 
 #include <string>
 #include <cstdio>
+#include <cstdint>
 
 // Simple wrapper for an IPv4 address.
 

--- a/Source/Shared/Core/Utils/Protobuf.cpp
+++ b/Source/Shared/Core/Utils/Protobuf.cpp
@@ -162,7 +162,7 @@ bool DecodedProtobufRegistry::DecodeField(DecodedProtobufMessage* Message, googl
         }
     }
 
-    return nullptr;
+    return false;
 }
 
 const DecodedProtobufMessage* DecodedProtobufRegistry::Decode(const std::string& messageName, const uint8_t* data, size_t length)

--- a/Source/Shared/Platform/Platform.h
+++ b/Source/Shared/Platform/Platform.h
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include <string>
 #include "Shared/Core/Utils/Event.h"
 
 // ========================================================================

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,96 @@
+# native deps
+{
+    lib
+    , cmake
+    , pkg-config
+    , removeReferencesTo
+    , writeShellApplication
+    , jq
+}:
+
+# build deps
+{
+    stdenv
+    , libuuid
+}:
+
+with builtins;
+with lib;
+
+let
+    pkg = stdenv.mkDerivation rec {
+        name = "ds3os";
+
+        src = with fileset; toSource {
+            root = ./.;
+            fileset = unions [ ./CMakeLists.txt ./Source ./Tools/Build ];
+        };
+
+        nativeBuildInputs = [ cmake pkg-config removeReferencesTo ];
+        buildInputs = [ libuuid ];
+
+        enableParallelBuilding = true;
+
+        installPhase = ''
+            install -Dm755 ../bin/x64_release/libsteam_api.so $out/lib/libsteam_api.so
+            install -Dm755 ../bin/x64_release/Server $out/bin/Server
+            mkdir -p $out/share/ds3os
+            cp -R ../bin/x64_release/WebUI $out/share/ds3os/WebUI
+            '';
+
+        # google's generated protobuf headers puts absolute file path garbage into the binaries
+        # which will break reproducible builds
+        fixupPhase = ''
+            find "$out" -type f -exec remove-references-to -t "${src}" '{}' +
+            '';
+
+        cmakeFlags = [
+            # Fix third party builds
+            "-DCMAKE_C_STANDARD=99"
+            "-DCMAKE_C_FLAGS=-Wno-implicit-function-declaration"
+        ];
+
+        # Can't pass multiple flags through cmakeFlags *sigh*
+        # https://github.com/NixOS/nixpkgs/issues/114044
+        # Though these really should be fixed in ds3os itself
+        NIX_CFLAGS_COMPILE = [ "-Wno-format-security" "-Wno-non-pod-varargs" ];
+
+        meta = {
+            homepage = "https://github.com/TLeonardUK/ds3os";
+            license = licenses.mit;
+            platforms = [ "x86_64-linux" ];
+        };
+    };
+in writeShellApplication {
+    runtimeInputs = [ jq ];
+    name = "ds3os";
+    text = ''
+        tmp="$(mktemp -d)"
+        trap 'rm -rf "$tmp"' EXIT
+        cd "$tmp"
+
+        export LD_LIBRARY_PATH="${pkg}/lib:''${LD_LIBRARY_PATH:-}"
+        config="''${XDG_CONFIG_HOME:-$HOME/.config/ds3os}"
+        mkdir -p "$config"
+
+        if [[ -f "$config/default/config.json" ]]; then
+            game_type="$(jq -r '.GameType' "$config/default/config.json")"
+        fi
+
+        case "''${game_type:-DarkSouls3}" in
+            DarkSouls2)
+                echo "GameType: DarkSouls2"
+                echo 335300 > steam_appid.txt
+                ;;
+            DarkSouls3)
+                echo "GameType: DarkSouls3"
+                echo 374320 > steam_appid.txt
+                ;;
+        esac
+
+        ln -sf "${pkg}/share/ds3os/WebUI" .
+        ln -sf "${pkg}/bin/Server" .
+        ln -sf "$config" Saved
+        exec ./Server
+        '';
+}

--- a/default.nix
+++ b/default.nix
@@ -91,6 +91,6 @@ in writeShellApplication {
         ln -sf "${pkg}/share/ds3os/WebUI" .
         ln -sf "${pkg}/bin/Server" .
         ln -sf "$config" Saved
-        exec ./Server
+        exec ./Server "$@"
         '';
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1709397644,
+        "narHash": "sha256-vZa1Ks/wgXERu06NeVJT8JtotqINSX/pPb/VaogIg1U=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "55ead8c56aa6b255e8c93b1c2c5f87bfa98546be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -15,5 +15,23 @@
       packages.default = pkgs.callPackage ds3os {};
       # nix build .#clang
       packages.clang = pkgs.callPackage ds3os { stdenv = pkgs.clangStdenv; };
+      # nix run .#master-server
+      apps.master-server = with pkgs; {
+        type = "app";
+        program = writeShellApplication {
+            name = "app";
+            runtimeInputs = [ nodejs ];
+            text = ''
+              tmp="$(mktemp -d)"
+              trap 'rm -rf "$tmp"' EXIT
+              cd "$tmp"
+              ln -sf ${./Source/MasterServer/package.json} package.json
+              ln -sf ${./Source/MasterServer/package-lock.json} package-lock.json
+              ln -sf ${./Source/MasterServer/src} src
+              npm ci --loglevel verbose --nodedir=${nodejs}/include/node
+              NODE_PATH="$tmp/node_modules" npm run start
+              '';
+        } + "/bin/app";
+      };
     }));
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,19 @@
+{
+  description = "ds3os flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { nixpkgs, flake-utils, ... }:
+    (flake-utils.lib.eachSystem [ "x86_64-linux" ] (system: let
+      pkgs = nixpkgs.outputs.legacyPackages.${system};
+      ds3os = pkgs.callPackage ./default.nix {};
+    in {
+      # nix build .
+      packages.default = pkgs.callPackage ds3os {};
+      # nix build .#clang
+      packages.clang = pkgs.callPackage ds3os { stdenv = pkgs.clangStdenv; };
+    }));
+}


### PR DESCRIPTION
* Adds flake.nix and default.nix for use with the nix package manager
* Adds ci jobs that builds using both clang and gcc (lots of warnings btw)
* Some minor fixes to make the project build on newer clang and gcc
* Instructions in readme
* Add option to run the main-server easily as well
* Add support for env variable bypass for the steam check in loader for linux users
* Run ci workflow in pull requests
https://github.com/TLeonardUK/ds3os/issues/30