### PR TITLE
Update DS2_ReplaceServerAddressHook.cpp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,10 +116,60 @@ jobs:
       with:
         path: ./linux.zip
         name: linux
-                                            
+ 
+  build-docker:
+    name: Build Docker
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout respository
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Generate Solution
+      shell: bash
+      working-directory: ${{github.workspace}}/Tools
+      run: ${{github.workspace}}/Tools/generate_make_release.sh
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1 
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Build and push master-server docker
+      uses: docker/build-push-action@v2
+      with:
+        context: ./Source/MasterServer/
+        file: ./Source/MasterServer/Dockerfile
+        push: true
+        tags: ${{ secrets.DOCKERHUB_USERNAME }}/ds3os-master:latest 
+
+    - name: Build and push server docker
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./DarkSouls3.Dockerfile
+        push: true
+        no-cache: true
+        tags: ${{ secrets.DOCKERHUB_USERNAME }}/ds3os:latest 
+
+    - name: Build and push server docker
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./DarkSouls2.Dockerfile
+        push: true
+        no-cache: true
+        tags: ${{ secrets.DOCKERHUB_USERNAME }}/ds2os:latest 
+                                  
   make-release:
     name: Make Release
-    needs: [ build-windows, build-linux]
+    needs: [ build-windows, build-linux, build-docker]
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,7 @@ jobs:
                                   
   make-release:
     name: Make Release
-    needs: [ build-windows, build-linux, build-docker]
+    needs: [ build-windows, build-linux, build-docker ]
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,60 +116,10 @@ jobs:
       with:
         path: ./linux.zip
         name: linux
-        
-  build-docker:
-    name: Build Docker
-    runs-on: ubuntu-20.04
-
-    steps:
-    - name: Checkout respository
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-
-    - name: Generate Solution
-      shell: bash
-      working-directory: ${{github.workspace}}/Tools
-      run: ${{github.workspace}}/Tools/generate_make_release.sh
-      
-    - name: Login to DockerHub
-      uses: docker/login-action@v1 
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-      
-    - name: Build and push master-server docker
-      uses: docker/build-push-action@v2
-      with:
-        context: ./Source/MasterServer/
-        file: ./Source/MasterServer/Dockerfile
-        push: true
-        tags: ${{ secrets.DOCKERHUB_USERNAME }}/ds3os-master:latest 
-                      
-    - name: Build and push server docker
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        file: ./DarkSouls3.Dockerfile
-        push: true
-        no-cache: true
-        tags: ${{ secrets.DOCKERHUB_USERNAME }}/ds3os:latest 
-                          
-    - name: Build and push server docker
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        file: ./DarkSouls2.Dockerfile
-        push: true
-        no-cache: true
-        tags: ${{ secrets.DOCKERHUB_USERNAME }}/ds2os:latest 
                                             
   make-release:
     name: Make Release
-    needs: [ build-windows, build-linux, build-docker ]
+    needs: [ build-windows, build-linux]
     runs-on: ubuntu-20.04
 
     steps:

--- a/Source/Injector/Hooks/DarkSouls2/DS2_ReplaceServerAddressHook.cpp
+++ b/Source/Injector/Hooks/DarkSouls2/DS2_ReplaceServerAddressHook.cpp
@@ -30,7 +30,7 @@ bool DS2_ReplaceServerAddressHook::PatchHostname(Injector& injector)
     std::wstring WideHostname = WidenString(Config.ServerHostname);
     size_t CopyLength = (WideHostname.size() + 1) * 2;
 
-    char* winePrefix = std::getenv("WINEPREFIX");
+    char* WinePrefix = std::getenv("WINEPREFIX");
 
     while (true)
     {
@@ -48,9 +48,9 @@ bool DS2_ReplaceServerAddressHook::PatchHostname(Injector& injector)
             {
                 continue;
             }
-            //if i'm not running in wine do the check
-            if (winePrefix == nullptr) {
-                Log("you are using windows");
+
+            if (WinePrefix == nullptr)
+            {
                 if (((info.Protect & PAGE_READWRITE) == 0 && (info.Protect & PAGE_EXECUTE_READWRITE) == 0))
                 {
                     continue;
@@ -83,7 +83,7 @@ bool DS2_ReplaceServerAddressHook::PatchHostname(Injector& injector)
 
 bool DS2_ReplaceServerAddressHook::PatchKey(Injector& injector)
 {
-    char* winePrefix = std::getenv("WINEPREFIX");
+    char* WinePrefix = std::getenv("WINEPREFIX");
 
     while (true)
     {
@@ -107,11 +107,11 @@ bool DS2_ReplaceServerAddressHook::PatchKey(Injector& injector)
         {
             // If the memory is not writable yet, modify its protection (steam drm fucks with the protection during boot).
             MEMORY_BASIC_INFORMATION info;
-            // If the programm is running on wine
-            if(winePrefix != nullptr)
+            
+            if (WinePrefix != nullptr)
             {
-                Log("you are using wine");
-                if (VirtualQuery((void*)key, &info, sizeof(info)) == 0) //wine doesn't emulate memory seafe features of windows {il TroncoNinja e' stato qui}
+                // Do the check because Wine doesn't emulate memory seafe features of Windows
+                if (VirtualQuery((void*)key, &info, sizeof(info)) == 0)
                 {
                     continue;
                 }

--- a/Source/Injector/Hooks/DarkSouls2/DS2_ReplaceServerAddressHook.cpp
+++ b/Source/Injector/Hooks/DarkSouls2/DS2_ReplaceServerAddressHook.cpp
@@ -30,6 +30,8 @@ bool DS2_ReplaceServerAddressHook::PatchHostname(Injector& injector)
     std::wstring WideHostname = WidenString(Config.ServerHostname);
     size_t CopyLength = (WideHostname.size() + 1) * 2;
 
+    char* winePrefix = std::getenv("WINEPREFIX");
+
     while (true)
     {
         std::vector<intptr_t> address_matches = injector.SearchString({
@@ -46,9 +48,13 @@ bool DS2_ReplaceServerAddressHook::PatchHostname(Injector& injector)
             {
                 continue;
             }
-            if (((info.Protect & PAGE_READWRITE) == 0 && (info.Protect & PAGE_EXECUTE_READWRITE) == 0))
-            {
-                continue;
+            //if i'm not running in wine do the check
+            if (winePrefix == nullptr) {
+                Log("you are using windows");
+                if (((info.Protect & PAGE_READWRITE) == 0 && (info.Protect & PAGE_EXECUTE_READWRITE) == 0))
+                {
+                    continue;
+                }
             }
 
             wchar_t* ptr = (wchar_t*)key;
@@ -77,6 +83,8 @@ bool DS2_ReplaceServerAddressHook::PatchHostname(Injector& injector)
 
 bool DS2_ReplaceServerAddressHook::PatchKey(Injector& injector)
 {
+    char* winePrefix = std::getenv("WINEPREFIX");
+
     while (true)
     {
         const RuntimeConfig& Config = Injector::Instance().GetConfig();
@@ -99,10 +107,22 @@ bool DS2_ReplaceServerAddressHook::PatchKey(Injector& injector)
         {
             // If the memory is not writable yet, modify its protection (steam drm fucks with the protection during boot).
             MEMORY_BASIC_INFORMATION info;
-            if (VirtualQuery((void*)key, &info, sizeof(info)) == 0 ||
-                ((info.Protect & PAGE_READWRITE) == 0 && (info.Protect & PAGE_EXECUTE_READWRITE) == 0))
+            // If the programm is running on wine
+            if(winePrefix != nullptr)
             {
-                continue;
+                Log("you are using wine");
+                if (VirtualQuery((void*)key, &info, sizeof(info)) == 0) //wine doesn't emulate memory seafe features of windows {il TroncoNinja e' stato qui}
+                {
+                    continue;
+                }
+            }
+            else
+            {
+                if (VirtualQuery((void*)key, &info, sizeof(info)) == 0 ||
+                    ((info.Protect & PAGE_READWRITE) == 0 && (info.Protect & PAGE_EXECUTE_READWRITE) == 0))
+                {
+                    continue;
+                }
             }
 
             memcpy((char*)key, Config.ServerPublicKey.c_str(), CopyLength);


### PR DESCRIPTION
fix for wine check in ds2, if you are running in wine(proton) ignore check for memory safety features that aren't supported.
the injector file compiled in this version was also tested with the 41.0 version (currently working on linux for the official unofficial server only)