### PR TITLE
DS2 Drangleic invasion quirk fix

### DIFF
--- a/Protobuf/DarkSouls2/DS2_Frpg2RequestMessage.proto
+++ b/Protobuf/DarkSouls2/DS2_Frpg2RequestMessage.proto
@@ -733,7 +733,7 @@ message RequestBreakInTarget {
 	required uint32 online_area_id = 1;
 	required uint32 cell_id = 2;
 	required uint32 player_id = 3;
-	required BreakInType type = 4;
+	optional BreakInType type = 4;
 }
 
 message RequestBreakInTargetResponse {
@@ -745,7 +745,7 @@ message RequestGetBreakInTargetList {
 	required uint32 cell_id = 2;         // 101030, 101910
 	required uint32 max_targets = 3;     // 5
 	required MatchingParameter matching_parameter = 4;
-	required BreakInType type = 5;       
+	optional BreakInType type = 5;
 }
 
 message RequestGetBreakInTargetListResponse {

--- a/Source/Server.DarkSouls2/Protobuf/Generated/DS2_Frpg2RequestMessage.pb.cc
+++ b/Source/Server.DarkSouls2/Protobuf/Generated/DS2_Frpg2RequestMessage.pb.cc
@@ -28056,7 +28056,7 @@ bool RequestBreakInTarget::MergePartialFromCodedStream(
         break;
       }
 
-      // required .DS2_Frpg2RequestMessage.BreakInType type = 4;
+      // optional .DS2_Frpg2RequestMessage.BreakInType type = 4;
       case 4: {
         if (tag == 32) {
          parse_type:
@@ -28117,7 +28117,7 @@ void RequestBreakInTarget::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteUInt32(3, this->player_id(), output);
   }
 
-  // required .DS2_Frpg2RequestMessage.BreakInType type = 4;
+  // optional .DS2_Frpg2RequestMessage.BreakInType type = 4;
   if (has_type()) {
     ::google::protobuf::internal::WireFormatLite::WriteEnum(
       4, this->type(), output);
@@ -28153,7 +28153,7 @@ int RequestBreakInTarget::ByteSize() const {
           this->player_id());
     }
 
-    // required .DS2_Frpg2RequestMessage.BreakInType type = 4;
+    // optional .DS2_Frpg2RequestMessage.BreakInType type = 4;
     if (has_type()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::EnumSize(this->type());
@@ -28199,7 +28199,7 @@ void RequestBreakInTarget::CopyFrom(const RequestBreakInTarget& from) {
 }
 
 bool RequestBreakInTarget::IsInitialized() const {
-  if ((_has_bits_[0] & 0x0000000f) != 0x0000000f) return false;
+  if ((_has_bits_[0] & 0x00000007) != 0x00000007) return false;
 
   return true;
 }
@@ -28543,7 +28543,7 @@ bool RequestGetBreakInTargetList::MergePartialFromCodedStream(
         break;
       }
 
-      // required .DS2_Frpg2RequestMessage.BreakInType type = 5;
+      // optional .DS2_Frpg2RequestMessage.BreakInType type = 5;
       case 5: {
         if (tag == 40) {
          parse_type:
@@ -28610,7 +28610,7 @@ void RequestGetBreakInTargetList::SerializeWithCachedSizes(
       4, this->matching_parameter(), output);
   }
 
-  // required .DS2_Frpg2RequestMessage.BreakInType type = 5;
+  // optional .DS2_Frpg2RequestMessage.BreakInType type = 5;
   if (has_type()) {
     ::google::protobuf::internal::WireFormatLite::WriteEnum(
       5, this->type(), output);
@@ -28653,7 +28653,7 @@ int RequestGetBreakInTargetList::ByteSize() const {
           this->matching_parameter());
     }
 
-    // required .DS2_Frpg2RequestMessage.BreakInType type = 5;
+    // optional .DS2_Frpg2RequestMessage.BreakInType type = 5;
     if (has_type()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::EnumSize(this->type());
@@ -28702,7 +28702,7 @@ void RequestGetBreakInTargetList::CopyFrom(const RequestGetBreakInTargetList& fr
 }
 
 bool RequestGetBreakInTargetList::IsInitialized() const {
-  if ((_has_bits_[0] & 0x0000001f) != 0x0000001f) return false;
+  if ((_has_bits_[0] & 0x0000000f) != 0x0000000f) return false;
 
   if (has_matching_parameter()) {
     if (!this->matching_parameter().IsInitialized()) return false;

--- a/Source/Server.DarkSouls2/Protobuf/Generated/DS2_Frpg2RequestMessage.pb.h
+++ b/Source/Server.DarkSouls2/Protobuf/Generated/DS2_Frpg2RequestMessage.pb.h
@@ -12171,7 +12171,7 @@ class RequestBreakInTarget : public ::google::protobuf::MessageLite {
   inline ::google::protobuf::uint32 player_id() const;
   inline void set_player_id(::google::protobuf::uint32 value);
 
-  // required .DS2_Frpg2RequestMessage.BreakInType type = 4;
+  // optional .DS2_Frpg2RequestMessage.BreakInType type = 4;
   inline bool has_type() const;
   inline void clear_type();
   static const int kTypeFieldNumber = 4;
@@ -12382,7 +12382,7 @@ class RequestGetBreakInTargetList : public ::google::protobuf::MessageLite {
   inline ::DS2_Frpg2RequestMessage::MatchingParameter* release_matching_parameter();
   inline void set_allocated_matching_parameter(::DS2_Frpg2RequestMessage::MatchingParameter* matching_parameter);
 
-  // required .DS2_Frpg2RequestMessage.BreakInType type = 5;
+  // optional .DS2_Frpg2RequestMessage.BreakInType type = 5;
   inline bool has_type() const;
   inline void clear_type();
   static const int kTypeFieldNumber = 5;
@@ -31389,7 +31389,7 @@ inline void RequestBreakInTarget::set_player_id(::google::protobuf::uint32 value
   // @@protoc_insertion_point(field_set:DS2_Frpg2RequestMessage.RequestBreakInTarget.player_id)
 }
 
-// required .DS2_Frpg2RequestMessage.BreakInType type = 4;
+// optional .DS2_Frpg2RequestMessage.BreakInType type = 4;
 inline bool RequestBreakInTarget::has_type() const {
   return (_has_bits_[0] & 0x00000008u) != 0;
 }
@@ -31539,7 +31539,7 @@ inline void RequestGetBreakInTargetList::set_allocated_matching_parameter(::DS2_
   // @@protoc_insertion_point(field_set_allocated:DS2_Frpg2RequestMessage.RequestGetBreakInTargetList.matching_parameter)
 }
 
-// required .DS2_Frpg2RequestMessage.BreakInType type = 5;
+// optional .DS2_Frpg2RequestMessage.BreakInType type = 5;
 inline bool RequestGetBreakInTargetList::has_type() const {
   return (_has_bits_[0] & 0x00000010u) != 0;
 }


### PR DESCRIPTION
Hello there.

In DS2OS, invasions seem to work flawlessly in most of the game.

However, if someone tries to invade in Drangleic Castle, the server panics and restarts.

Turns out both `RequestGetBreakInTargetList` and `RequestBreakInTarget` received from the client in Drangleic come without a `BreakInType`.

This probably has something to do with the various types of invasions in that area, namely the Looking Glass K***ht ones.

Turning it optional seems to fix the issue without any noticeable side effects.


```
[libprotobuf ERROR /build/Source/ThirdParty/protobuf-2.6.1rc1/src/google/protobuf/message_lite.cc:123] Can't parse message of type "DS2_Frpg2RequestMessage.RequestGetBreakInTargetList" because it is missing required fields: (cannot determine missing fields for lite message)
(...)
2026-03-29 23:44:55 � Warning � 2:Val                               � Failed to deserialize protobuf instance for message: type=0x000003d2 index=0x000000dc
2026-03-30 05:15:46 � Warning � 1:Val                               � Decoded:
��5U
```

```
$ xxd RequestGetBreakInTargetList.bin
00000000: 08d0 c2d1 0910 0018 0522 1d08 e89d 0110  ........."......
00000010: f301 1802 209a 0130 0038 0240 0048 0150  .... ..0.8.@.H.P
00000020: 0058 0060 a5c4 ca04 2803                 .X.`....(.
```

```
$ < ~/RequestGetBreakInTargetList.bin | protoc --decode DS2_Frpg2RequestMessage.RequestGetBreakInTargetList DS2_Frpg2RequestMessage.proto
warning:  Input message is missing required fields:  type
online_area_id: 20210000
cell_id: 0
max_targets: 5
matching_parameter {
  calibration_version: 20200
  soul_level: 243
  clear_count: 2
  unknown_4: 154
  covenant: 0
  unknown_7: 2
  disable_cross_region_play: 0
  unknown_9: 1
  unknown_10: 0
  name_engraved_ring: 0
  soul_memory: 9609765
}
5: 3
```

And after patching `RequestGetBreakInTargetList`, `RequestBreakInTarget` becomes the problematic one;

```
[libprotobuf ERROR /build/Source/ThirdParty/protobuf-2.6.1rc1/src/google/protobuf/message_lite.cc:123] Can't parse message of type "DS2_Frpg2RequestMessage.RequestBreakInTarget" because it is missing required fields: (cannot determine missing fields for lite message)
2026-03-31 00:11:44 � Warning � 16:exploud03                        � Failed to deserialize protobuf instance for message: type=0x000003d3 index=0x00000047
2026-03-31 00:11:44 � Warning � 16:exploud03                        � Decoded:
message FailedMessage {
	required int64 field_1 = 1; // 20210000
	required int64 field_2 = 2; // 0
	required int64 field_3 = 3; // 2
	required int64 field_4 = 4; // 3
}
```

```
$ xxd RequestBreakInTarget.bin
00000000: 08d0 c2d1 0910 0018 0220 03              ......... .
```

```
$ < ~/RequestBreakInTarget.bin | protoc --decode DS2_Frpg2RequestMessage.RequestBreakInTarget DS2_Frpg2RequestMessage.proto
warning:  Input message is missing required fields:  type
online_area_id: 20210000
cell_id: 0
player_id: 2
4: 3
```

Attached are the binary dumps for both failed messages as extracted by DS2OS.

[RequestBreakInTarget_RequestGetBreakInTargetList.zip](https://github.com/user-attachments/files/26364917/RequestBreakInTarget_RequestGetBreakInTargetList.zip)

With this adjustment Drangleic invasions seem to work fine, and the ones outside remain functional.

Please review.

Thank you for your work!