### PR TITLE
DS2 fix for missing yellow signs when invasions are disabled

### DIFF
--- a/Protobuf/DarkSouls2/DS2_Frpg2RequestMessage.proto
+++ b/Protobuf/DarkSouls2/DS2_Frpg2RequestMessage.proto
@@ -573,7 +573,9 @@ message SignInfo {
 
 enum SignType {
     // TODO: Probably a mirror knight sign type as well in here.
+    SignType_WhiteSoapstoneSunlight = 0;
     SignType_WhiteSoapstone = 1;
+    SignType_SmallWhiteSoapstoneSunlight = 2;
     SignType_SmallWhiteSoapstone = 3;
     SignType_RedSoapstone = 4;
     SignType_Dragon = 6;

--- a/Source/Server.DarkSouls2/Protobuf/Generated/DS2_Frpg2RequestMessage.pb.cc
+++ b/Source/Server.DarkSouls2/Protobuf/Generated/DS2_Frpg2RequestMessage.pb.cc
@@ -729,7 +729,9 @@ bool SummonErrorId_IsValid(int value) {
 
 bool SignType_IsValid(int value) {
   switch(value) {
+    case 0:
     case 1:
+    case 2:
     case 3:
     case 4:
     case 6:
@@ -22006,7 +22008,7 @@ void SignData::SharedCtor() {
   player_struct_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   player_steam_id_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   cell_id_ = GOOGLE_LONGLONG(0);
-  sign_type_ = 1;
+  sign_type_ = 0;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -22053,7 +22055,18 @@ SignData* SignData::New() const {
 }
 
 void SignData::Clear() {
+#define OFFSET_OF_FIELD_(f) (reinterpret_cast<char*>(      \
+  &reinterpret_cast<SignData*>(16)->f) - \
+   reinterpret_cast<char*>(16))
+
+#define ZR_(first, last) do {                              \
+    size_t f = OFFSET_OF_FIELD_(first);                    \
+    size_t n = OFFSET_OF_FIELD_(last) - f + sizeof(last);  \
+    ::memset(&first, 0, n);                                \
+  } while (0)
+
   if (_has_bits_[0 / 32] & 127) {
+    ZR_(cell_id_, sign_type_);
     if (has_sign_info()) {
       if (sign_info_ != NULL) sign_info_->::DS2_Frpg2RequestMessage::SignInfo::Clear();
     }
@@ -22071,9 +22084,11 @@ void SignData::Clear() {
         player_steam_id_->clear();
       }
     }
-    cell_id_ = GOOGLE_LONGLONG(0);
-    sign_type_ = 1;
   }
+
+#undef OFFSET_OF_FIELD_
+#undef ZR_
+
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   mutable_unknown_fields()->clear();
 }

--- a/Source/Server.DarkSouls2/Protobuf/Generated/DS2_Frpg2RequestMessage.pb.h
+++ b/Source/Server.DarkSouls2/Protobuf/Generated/DS2_Frpg2RequestMessage.pb.h
@@ -286,14 +286,16 @@ const SummonErrorId SummonErrorId_MAX = SummonErrorId_SignHasDisappeared;
 const int SummonErrorId_ARRAYSIZE = SummonErrorId_MAX + 1;
 
 enum SignType {
+  SignType_WhiteSoapstoneSunlight = 0,
   SignType_WhiteSoapstone = 1,
+  SignType_SmallWhiteSoapstoneSunlight = 2,
   SignType_SmallWhiteSoapstone = 3,
   SignType_RedSoapstone = 4,
   SignType_Dragon = 6,
   SignType_MirrorKnight = 99
 };
 bool SignType_IsValid(int value);
-const SignType SignType_MIN = SignType_WhiteSoapstone;
+const SignType SignType_MIN = SignType_WhiteSoapstoneSunlight;
 const SignType SignType_MAX = SignType_MirrorKnight;
 const int SignType_ARRAYSIZE = SignType_MAX + 1;
 
@@ -29385,7 +29387,7 @@ inline void SignData::clear_has_sign_type() {
   _has_bits_[0] &= ~0x00000040u;
 }
 inline void SignData::clear_sign_type() {
-  sign_type_ = 1;
+  sign_type_ = 0;
   clear_has_sign_type();
 }
 inline ::DS2_Frpg2RequestMessage::SignType SignData::sign_type() const {

--- a/Source/Server.DarkSouls2/Server/GameService/GameManagers/Signs/DS2_SignManager.cpp
+++ b/Source/Server.DarkSouls2/Server/GameService/GameManagers/Signs/DS2_SignManager.cpp
@@ -132,11 +132,11 @@ bool DS2_SignManager::CanMatchWith(const DS2_Frpg2RequestMessage::MatchingParame
         }
     case DS2_Frpg2RequestMessage::SignType_WhiteSoapstone:
         {
-            return Config.DS2_SmallWhiteSoapstoneMatchingParameters.CheckMatch(Host.soul_memory(), Match.soul_memory(), Host.name_engraved_ring() > 0);
+            return Config.DS2_WhiteSoapstoneMatchingParameters.CheckMatch(Host.soul_memory(), Match.soul_memory(), Host.name_engraved_ring() > 0);
         }
     case DS2_Frpg2RequestMessage::SignType_SmallWhiteSoapstone:
         {
-            return Config.DS2_WhiteSoapstoneMatchingParameters.CheckMatch(Host.soul_memory(), Match.soul_memory(), Host.name_engraved_ring() > 0);
+            return Config.DS2_SmallWhiteSoapstoneMatchingParameters.CheckMatch(Host.soul_memory(), Match.soul_memory(), Host.name_engraved_ring() > 0);
         }
     case DS2_Frpg2RequestMessage::SignType_Dragon:
         {

--- a/Source/Server.DarkSouls2/Server/GameService/GameManagers/Signs/DS2_SignManager.cpp
+++ b/Source/Server.DarkSouls2/Server/GameService/GameManagers/Signs/DS2_SignManager.cpp
@@ -118,7 +118,13 @@ bool DS2_SignManager::CanMatchWith(const DS2_Frpg2RequestMessage::MatchingParame
     const RuntimeConfig& Config = ServerInstance->GetConfig();
 
     // Sign globally disabled?
-    bool IsDisabled = (SignType != DS2_Frpg2RequestMessage::SignType_SmallWhiteSoapstone && SignType != DS2_Frpg2RequestMessage::SignType_WhiteSoapstone) ? Config.DisableInvasions : Config.DisableCoop;
+    bool IsDisabled = (
+                SignType != DS2_Frpg2RequestMessage::SignType_SmallWhiteSoapstoneSunlight
+             && SignType != DS2_Frpg2RequestMessage::SignType_SmallWhiteSoapstone
+             && SignType != DS2_Frpg2RequestMessage::SignType_WhiteSoapstoneSunlight
+             && SignType != DS2_Frpg2RequestMessage::SignType_WhiteSoapstone
+         ) ? Config.DisableInvasions : Config.DisableCoop;
+
     if (IsDisabled)
     {
         return false;
@@ -130,10 +136,12 @@ bool DS2_SignManager::CanMatchWith(const DS2_Frpg2RequestMessage::MatchingParame
         {
             return Config.DS2_RedSoapstoneMatchingParameters.CheckMatch(Host.soul_memory(), Match.soul_memory(), Host.name_engraved_ring() > 0);
         }
+    case DS2_Frpg2RequestMessage::SignType_WhiteSoapstoneSunlight:
     case DS2_Frpg2RequestMessage::SignType_WhiteSoapstone:
         {
             return Config.DS2_WhiteSoapstoneMatchingParameters.CheckMatch(Host.soul_memory(), Match.soul_memory(), Host.name_engraved_ring() > 0);
         }
+    case DS2_Frpg2RequestMessage::SignType_SmallWhiteSoapstoneSunlight:
     case DS2_Frpg2RequestMessage::SignType_SmallWhiteSoapstone:
         {
             return Config.DS2_SmallWhiteSoapstoneMatchingParameters.CheckMatch(Host.soul_memory(), Match.soul_memory(), Host.name_engraved_ring() > 0);


### PR DESCRIPTION
Good evening.

During a session with friends, one of them tried to invade in Drangleic Castle, causing the issue described in https://github.com/TLeonardUK/ds3os/pull/231

As a mitigation, we disabled invasions.

After that the white signs of participants beloging to the Warrior of Sunlight covenant stopped showing up, although they were still accounted for in the WebUI's `Live Summon Signs`.

This is similar to what's described in https://github.com/TLeonardUK/ds3os/issues/222

Upon closer inspection it seems the `SignType` value for the white soapstones while a member of Warrior of Sunlight is different and they aren't included in the sign disabling logic.

The proposed changes include these two `SignType`, restoring yellow signs when `Disable Invasions` is on.

Thank you for your time!


**WhiteSoapstone**

```
$ < ~/RequestCreateSign_White.bin | protoc --decode DS2_Frpg2RequestMessage.RequestCreateSign DS2_Frpg2RequestMessage.proto
online_area_id: 10170000
matching_parameter {
  calibration_version: 20200
  soul_level: 214
  clear_count: 2
  unknown_4: 154
  covenant: 4 // Way of Blue
  unknown_7: 2
  disable_cross_region_play: 0
  unknown_9: 1
  unknown_10: 0
  name_engraved_ring: 0
  soul_memory: 4768563
}
player_struct: "\006\000\000\000\315\004%\003%\023\362\001\000\r\000\000V\000a\000l\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
cell_id: 20972545
sign_type: 1
```


**WhiteSoapstone** + **Warrior of Sunlight covenant**

```
$ < ~/RequestCreateSign_Sunlight.bin | protoc --decode DS2_Frpg2RequestMessage.RequestCreateSign DS2_Frpg2RequestMessage.proto
online_area_id: 10170000
matching_parameter {
  calibration_version: 20200
  soul_level: 214
  clear_count: 2
  unknown_4: 154
  covenant: 1 // Warrior of Sunlight
  unknown_7: 2
  disable_cross_region_play: 0
  unknown_9: 1
  unknown_10: 0
  name_engraved_ring: 0
  soul_memory: 4768563
}
player_struct: "\006\000\000\000\224\004#\003\321\023~\003\000\r\000\000V\000a\000l\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
cell_id: 20972545
sign_type: 0
```


**Small WhiteSoapstone** + **Warrior of Sunlight covenant**

```
$ < ~/RequestCreateSign_SmallSunlight.bin | protoc --decode DS2_Frpg2RequestMessage.RequestCreateSign DS2_Frpg2RequestMessage.proto
online_area_id: 10170000
matching_parameter {
  calibration_version: 20200
  soul_level: 214
  clear_count: 2
  unknown_4: 154
  covenant: 1 // Warrior of Sunlight
  unknown_7: 2
  disable_cross_region_play: 0
  unknown_9: 1
  unknown_10: 0
  name_engraved_ring: 0
  soul_memory: 4769363
}
player_struct: "\006\000\000\000\223\004#\003\362\023~\004\000\r\000\000V\000a\000l\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
cell_id: 20972545
sign_type: 2
```


**RedSoapstone** + **Warrior of Sunlight covenant** has the expected `SignType`

```
$ < ~/RequestCreateSign_RedSunlight.bin | protoc --decode DS2_Frpg2RequestMessage.RequestCreateSign DS2_Frpg2RequestMessage.proto
online_area_id: 10170000
matching_parameter {
  calibration_version: 20200
  soul_level: 214
  clear_count: 2
  unknown_4: 154
  covenant: 1 // Warrior of Sunlight
  unknown_7: 2
  disable_cross_region_play: 0
  unknown_9: 1
  unknown_10: 0
  name_engraved_ring: 0
  soul_memory: 4769363
}
player_struct: "\006\000\000\000\300\004%\003V\023\226\007\000\r\000\000V\000a\000l\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
cell_id: 20972545
sign_type: 4 // Same as SignType_RedSoapstone
```